### PR TITLE
Simplify SignalR connection

### DIFF
--- a/ChatServer/ChatClientXam/ChatClientXam/ViewModel/MainViewModel.cs
+++ b/ChatServer/ChatClientXam/ChatClientXam/ViewModel/MainViewModel.cs
@@ -139,16 +139,8 @@ namespace ChatClientXam.ViewModel
             {
                 IsBusy = true;
 
-                var client = new HttpClient();
-                var negotiateJson = await client.GetStringAsync($"{HostName}/api/negotiate");
-
-                var negotiateInfo = JsonConvert.DeserializeObject<NegotiateInfo>(negotiateJson);
-
                 _connection = new HubConnectionBuilder()
-                    .WithUrl(negotiateInfo.Url, options =>
-                    {
-                        options.AccessTokenProvider = async () => negotiateInfo.AccessToken;
-                    })
+                    .WithUrl($"{HostName}/api")
                     //.ConfigureLogging(builder =>
                     //{
                     //    builder.AddConsole();

--- a/ChatServer/ChatServer/Negotiate.cs
+++ b/ChatServer/ChatServer/Negotiate.cs
@@ -12,6 +12,7 @@ namespace ChatServer
             [HttpTrigger(
                 AuthorizationLevel.Anonymous,
                 "get",
+                "post",
                 Route = "negotiate")]
             HttpRequest req,
             [SignalRConnectionInfo(HubName = "simplechat")]


### PR DESCRIPTION
The connection will automatically append `/negotiate` to the URL passed to `withUrl()` to start the negotiation process, that's why we're calling it with `/api`. The rest should "just work".